### PR TITLE
Bug create zoom

### DIFF
--- a/src/app/api/zoom/post_meeting/route.ts
+++ b/src/app/api/zoom/post_meeting/route.ts
@@ -42,7 +42,6 @@ export async function GET(request: Request) {
         });
 
         const data = await res.json();
-        console.log(data);
         return NextResponse.json({ data });
     } catch (error) {
         return NextResponse.json({ error });

--- a/src/components/Templates/PaymentAppointmentSection/PaymentAppointmentSection2.tsx
+++ b/src/components/Templates/PaymentAppointmentSection/PaymentAppointmentSection2.tsx
@@ -1,4 +1,5 @@
 import LinkPrimary from '@/components/Atoms/Links/LinkPrimary/LinkPrimary';
+import Loading from '@/components/Molecules/Loaders/Loading/Loading';
 import LoadingFullPage from '@/components/Molecules/Loaders/LoadingFullPage/LoadingFullPage';
 import PaymentLater from '@/components/Molecules/PaymentLater/PaymentLater';
 import MercadoPagoPayment from '@/components/Organisms/MercadoPagoPayment/MercadoPagoPayment';
@@ -13,13 +14,13 @@ const PaymentAppointmentSection2 = () => {
 
     const router = useRouter();
 
-    const { appointmentExisted, appointment } = useAppointmentURLParams();
+    const { appointmentExisted,
+        appointment,
+        pageState,
+        setPageState } = useAppointmentURLParams();
     const { date } = appointment;
 
-    const [pageState, setPageState] = useState<{
-        loading: boolean;
-        error: string;
-    }>({ loading: false, error: "" });
+
 
     const onClickPayLater = async () => {
         try {
@@ -57,7 +58,7 @@ const PaymentAppointmentSection2 = () => {
 
                 <div className="flex flex-col justify-center pt-5 gap-2 w-full">
                     <PaymentReview appointment={appointment} />
-                    {(pageState.error === "" && appointmentExisted !== null) ? (
+                    {(pageState.error === "" && appointmentExisted !== null && !pageState.loading) ? (
                         <div className="flex-col items-center justify-center">
                             {<MercadoPagoPayment
                                 appointment={appointment} />}

--- a/src/utils/functions/utils.ts
+++ b/src/utils/functions/utils.ts
@@ -119,18 +119,11 @@ export const areDatesEqual = (dateA: Date, dateB: Date) => {
 export const createAppointment = (appointment: IAppointment, patient: IUserInfo) => {
   const { _id } = patient;
   const { date } = appointment;
-  // const dateParts = date.split("-");
-  // const newDate = new Date(
-  //   parseInt(dateParts[0]),
-  //   parseInt(dateParts[1]) - 1,
-  //   parseInt(dateParts[2])
-  // );
   const newAppointment: IAppointment = {
     ...appointment,
     patientId: _id,
     status: 'pending',
     price: 80,
-    // date: newDate as unknown as string,
   }
   return newAppointment;
 

--- a/src/utils/hooks/useAppointmentURLParams.ts
+++ b/src/utils/hooks/useAppointmentURLParams.ts
@@ -51,6 +51,8 @@ const useAppointmentURLParams = () => {
             }
             dispatch({ type: "SET_APPOINTMENT", payload: newAppointment });
             setAppointmentExisted(true);
+            setPageState({ loading: false, error: "" });
+
         }
 
         const uploadAppointment = async () => {
@@ -62,8 +64,8 @@ const useAppointmentURLParams = () => {
             setPageState({ loading: false, error: "" });
         }
 
-        setPageState({ loading: true, error: "" });
         if (appointmentExisted === null) {
+            setPageState({ loading: true, error: "" });
             getAppointmentData();
         } else {
             if (!appointmentExisted) {

--- a/src/utils/hooks/useAppointmentURLParams.ts
+++ b/src/utils/hooks/useAppointmentURLParams.ts
@@ -22,6 +22,11 @@ const useAppointmentURLParams = () => {
     const user: IUserState = useAppSelector((state: IState) => state.user);
     const { userInfo } = user;
 
+    const [pageState, setPageState] = useState<{
+        loading: boolean;
+        error: string;
+    }>({ loading: false, error: "" });
+
 
     useEffect(() => {
 
@@ -54,8 +59,10 @@ const useAppointmentURLParams = () => {
             } else {
                 await updateAppointmentField(appointment._id, "status", "pending");
             }
+            setPageState({ loading: false, error: "" });
         }
 
+        setPageState({ loading: true, error: "" });
         if (appointmentExisted === null) {
             getAppointmentData();
         } else {
@@ -69,7 +76,7 @@ const useAppointmentURLParams = () => {
         }
     }, [appointment, user, appointmentExisted])
 
-    return { appointmentExisted, appointment };
+    return { appointmentExisted, appointment, pageState, setPageState };
 
 }
 


### PR DESCRIPTION
Zoom appointments could not be created in production due to a not included delay when intializing the fetch from Zoom servers. Now, a loading page is included inside the reserve payment so users can pay only after the complete appointment (with the Zoom link) is created.